### PR TITLE
Add the domain name of the David Tvildiani Medical University

### DIFF
--- a/file/lib/domains/ge/edu/dtmu.txt
+++ b/file/lib/domains/ge/edu/dtmu.txt
@@ -1,0 +1,2 @@
+დავით ტვილდიანის სამედიცინო უნივერსიტეტი
+David Tvildiani Medical University


### PR DESCRIPTION
This pull request adds the domain name of the David Tvildiani Medical University. 

Main Domain: dtmu.edu.ge (It is redirected to dtmu.ge)
Domain: dtmu.ge

Thank you!